### PR TITLE
Modify elastic calculator

### DIFF
--- a/maml/apps/pes/_lammps.py
+++ b/maml/apps/pes/_lammps.py
@@ -384,6 +384,7 @@ class ElasticConstant(LMPStaticCalculator):
         jiggle=1e-5,
         maxiter=400,
         maxeval=1000,
+        full_matrix=False,
         **kwargs,
     ):
         """
@@ -400,6 +401,9 @@ class ElasticConstant(LMPStaticCalculator):
                 prevent atoms from staying on saddle points.
             maxiter (float): The maximum number of iteration. Default to 400.
             maxeval (float): The maximum number of evaluation. Default to 1000.
+            full_matrix (bool): If False, only c11, c12, c44 and bulk modulus are returned.
+                If True, 6 x 6 elastic matrices in the Voigt notation are returned.
+
         """
         self.ff_settings = ff_settings
         self.write_command = self._RESTART_CONFIG[potential_type]["write_command"]
@@ -409,6 +413,7 @@ class ElasticConstant(LMPStaticCalculator):
         self.jiggle = jiggle
         self.maxiter = maxiter
         self.maxeval = maxeval
+        self.full_matrix = full_matrix
         super().__init__(**kwargs)
 
     def _setup(
@@ -461,6 +466,10 @@ class ElasticConstant(LMPStaticCalculator):
         Parse results from dump files.
 
         """
+        if self.full_matrix:
+            voigt = np.loadtxt("voigt_tensor.txt")
+            return voigt
+
         C11, C12, C44, bulkmodulus = np.loadtxt("elastic.txt")
         return C11, C12, C44, bulkmodulus
 

--- a/maml/apps/pes/_lammps.py
+++ b/maml/apps/pes/_lammps.py
@@ -382,9 +382,6 @@ class ElasticConstant(LMPStaticCalculator):
         potential_type="external",
         deformation_size=1e-6,
         jiggle=1e-5,
-        lattice="bcc",
-        alat=5.0,
-        atom_type=1,
         maxiter=400,
         maxeval=1000,
         **kwargs,
@@ -401,29 +398,15 @@ class ElasticConstant(LMPStaticCalculator):
                 1e-2 to 1e-8, to confirm the results not depend on it.
             jiggle (float): The amount of random jiggle for atoms to
                 prevent atoms from staying on saddle points.
-            lattice (str): The lattice type of structure. e.g. bcc or diamond.
-                If lattice=None, the calculator expects input structures in the calculate method.
-            alat (float): The lattice constant of specific lattice and specie.
-                If alat=None, the calculator expects input structures in the calculate method.
-            atom_type (int): The specified atom type if more than 1 species
-                contained in the ff_settings. If atom_type=None, the calculator expects
-                input structures in the calculate method.
             maxiter (float): The maximum number of iteration. Default to 400.
             maxeval (float): The maximum number of evaluation. Default to 1000.
         """
         self.ff_settings = ff_settings
-        elements = ff_settings.elements
         self.write_command = self._RESTART_CONFIG[potential_type]["write_command"]
         self.read_command = self._RESTART_CONFIG[potential_type]["read_command"]
         self.restart_file = self._RESTART_CONFIG[potential_type]["restart_file"]
         self.deformation_size = deformation_size
         self.jiggle = jiggle
-        self.lattice = lattice
-        self.alat = alat
-        self.num_species = len(elements)
-        if isinstance(atom_type, str):
-            atom_type = elements.index(atom_type) + 1
-        self.atom_type = atom_type
         self.maxiter = maxiter
         self.maxeval = maxeval
         super().__init__(**kwargs)
@@ -443,19 +426,6 @@ class ElasticConstant(LMPStaticCalculator):
             displace_template = f.read()
 
         input_file = "in.elastic"
-        init_template = init_template.format(
-            deformation_size=self.deformation_size,
-            jiggle=self.jiggle,
-            maxiter=self.maxiter,
-            maxeval=self.maxeval,
-            lattice=self.lattice,
-            alat=self.alat,
-            num_species=self.num_species,
-            atom_type=self.atom_type,
-            masses="\n".join(["mass {} {}".format(i + 1, i + 1) for i in range(self.num_species)]),
-        )
-        init_template = init_template.splitlines()
-
         if isinstance(self.ff_settings, Potential):
             ff_settings = self.ff_settings.write_param()
         else:
@@ -463,58 +433,21 @@ class ElasticConstant(LMPStaticCalculator):
 
         with open(input_file, "w") as f:
             f.write(input_template.format(write_restart=self.write_command, restart_file=self.restart_file))
-        if None in [self.alat, self.lattice, self.atom_type]:
-            read_data = ["box             tilt large", "read_data       data.static"]
-            with open("init.mod", "w") as f:
-                f.write("\n".join(init_template[:-12] + read_data))
-        else:
-            with open("init.mod", "w") as f:
-                f.writelines("\n".join(init_template))
+
+        with open("init.mod", "w") as f:
+            f.write(
+                init_template.format(
+                    deformation_size=self.deformation_size,
+                    jiggle=self.jiggle,
+                    maxiter=self.maxiter,
+                    maxeval=self.maxeval,
+                )
+            )
         with open("potential.mod", "w") as f:
             f.write(potential_template.format(ff_settings="\n".join(ff_settings)))
         with open("displace.mod", "w") as f:
             f.write(displace_template.format(read_restart=self.read_command, restart_file=self.restart_file))
         return input_file
-
-    def calculate(self, structures=None):
-        """
-        Calculate the elastic constant given Potential class.
-        Args:
-            structures (list): A list of structures. If structures=None, the alat, lattice and atom_type
-                should not be None when initializing the calculator.
-
-        Returns:
-            List of elastic constants.
-        """
-        if structures:
-            if None not in [self.alat, self.lattice, self.atom_type]:
-                raise ValueError(
-                    "To calculate elastic constants of input structures, at least one of "
-                    "the alat, lattice and atom_type should be None when initializing the calculator."
-                )
-            result = super().calculate(structures=structures)
-        else:
-            if None in [self.alat, self.lattice, self.atom_type]:
-                raise ValueError(
-                    "Without providing input structures, the alat, lattice and atom_type "
-                    "should not be None when initializing the calculator."
-                )
-            with ScratchDir("."):
-                input_file = self._setup()
-                with subprocess.Popen([self.LMP_EXE, "-in", input_file], stdout=subprocess.PIPE) as p:
-                    stdout = p.communicate()[0]
-                    rc = p.returncode
-                if rc != 0:
-                    error_msg = "LAMMPS exited with return code %d" % rc
-                    msg = stdout.decode("utf-8").split("\n")[:-1]
-                    try:
-                        error_line = [i for i, m in enumerate(msg) if m.startswith("ERROR")][0]
-                        error_msg += ", ".join(msg[error_line:])
-                    except Exception:
-                        error_msg += msg[-1]
-                    raise RuntimeError(error_msg)
-                result = self._parse()
-        return result
 
     def _sanity_check(self, structure):
         """

--- a/maml/apps/pes/templates/defect/in.defect
+++ b/maml/apps/pes/templates/defect/in.defect
@@ -2,7 +2,7 @@
 
 units           metal
 
-atom_style      charge
+atom_style      atomic
 atom_modify     map array
 boundary        p p p
 atom_modify	    sort 0 0.0

--- a/maml/apps/pes/templates/efs/in.efs
+++ b/maml/apps/pes/templates/efs/in.efs
@@ -4,7 +4,7 @@
 clear
 units           metal
 boundary        p p p
-atom_style      charge
+atom_style      atomic
 
 # ------------------ ATOM DEFINITION -------------------
 box             tilt large

--- a/maml/apps/pes/templates/elastic/in.elastic
+++ b/maml/apps/pes/templates/elastic/in.elastic
@@ -162,6 +162,12 @@ variable poissonratio equal 1.0/(1.0+${{C11cubic}}/${{C12cubic}})
 #               C12 = 76.4 GPa
 #               C44 = 56.4 GPa
 print "${{C11all}} ${{C12all}} ${{C44all}} ${{bulkmodulus}}" file elastic.txt
+print "${{C11all}} ${{C12all}} ${{C13all}} ${{C14all}} ${{C15all}} ${{C16all}}" file    voigt_tensor.txt
+print "${{C21all}} ${{C22all}} ${{C23all}} ${{C24all}} ${{C25all}} ${{C26all}}" append  voigt_tensor.txt
+print "${{C31all}} ${{C32all}} ${{C33all}} ${{C34all}} ${{C35all}} ${{C36all}}" append  voigt_tensor.txt
+print "${{C41all}} ${{C42all}} ${{C43all}} ${{C44all}} ${{C45all}} ${{C46all}}" append  voigt_tensor.txt
+print "${{C51all}} ${{C52all}} ${{C53all}} ${{C54all}} ${{C55all}} ${{C56all}}" append  voigt_tensor.txt
+print "${{C61all}} ${{C62all}} ${{C63all}} ${{C64all}} ${{C65all}} ${{C66all}}" append  voigt_tensor.txt
 print "========================================="
 print "Components of the Elastic Constant Tensor"
 print "========================================="

--- a/maml/apps/pes/templates/elastic/in.elastic
+++ b/maml/apps/pes/templates/elastic/in.elastic
@@ -163,11 +163,11 @@ variable poissonratio equal 1.0/(1.0+${{C11cubic}}/${{C12cubic}})
 #               C44 = 56.4 GPa
 print "${{C11all}} ${{C12all}} ${{C44all}} ${{bulkmodulus}}" file elastic.txt
 print "${{C11all}} ${{C12all}} ${{C13all}} ${{C14all}} ${{C15all}} ${{C16all}}" file    voigt_tensor.txt
-print "${{C21all}} ${{C22all}} ${{C23all}} ${{C24all}} ${{C25all}} ${{C26all}}" append  voigt_tensor.txt
-print "${{C31all}} ${{C32all}} ${{C33all}} ${{C34all}} ${{C35all}} ${{C36all}}" append  voigt_tensor.txt
-print "${{C41all}} ${{C42all}} ${{C43all}} ${{C44all}} ${{C45all}} ${{C46all}}" append  voigt_tensor.txt
-print "${{C51all}} ${{C52all}} ${{C53all}} ${{C54all}} ${{C55all}} ${{C56all}}" append  voigt_tensor.txt
-print "${{C61all}} ${{C62all}} ${{C63all}} ${{C64all}} ${{C65all}} ${{C66all}}" append  voigt_tensor.txt
+print "${{C12all}} ${{C22all}} ${{C23all}} ${{C24all}} ${{C25all}} ${{C26all}}" append  voigt_tensor.txt
+print "${{C13all}} ${{C23all}} ${{C33all}} ${{C34all}} ${{C35all}} ${{C36all}}" append  voigt_tensor.txt
+print "${{C14all}} ${{C24all}} ${{C34all}} ${{C44all}} ${{C45all}} ${{C46all}}" append  voigt_tensor.txt
+print "${{C15all}} ${{C25all}} ${{C35all}} ${{C45all}} ${{C55all}} ${{C56all}}" append  voigt_tensor.txt
+print "${{C16all}} ${{C26all}} ${{C36all}} ${{C46all}} ${{C56all}} ${{C66all}}" append  voigt_tensor.txt
 print "========================================="
 print "Components of the Elastic Constant Tensor"
 print "========================================="

--- a/maml/apps/pes/templates/elastic/init.template
+++ b/maml/apps/pes/templates/elastic/init.template
@@ -35,15 +35,7 @@ variable        maxiter equal {maxiter}
 variable        maxeval equal {maxeval}
 variable        dmax equal 1.0e-2
 
-# generate the box and atom positions using a {lattice} lattice
-variable        a equal {alat}
-
-boundary	    p p p
-
-lattice         {lattice} $a
-region		    box prism 0 2.0 0 3.0 0 4.0 0.0 0.0 0.0
-create_box	    {num_species} box
-create_atoms	{atom_type} box
-
-# Need to set mass to something, just to satisfy LAMMPS
-{masses}
+# read structure from data.static
+box             tilt large
+read_data       data.static
+change_box  all triclinic

--- a/maml/apps/pes/templates/latt/in.latt
+++ b/maml/apps/pes/templates/latt/in.latt
@@ -3,7 +3,7 @@
 # --------------- INITIALIZATION ------------------
 clear
 units             metal
-atom_style        charge
+atom_style        atomic
 # ------------------ ATOM DEFINITION -------------------
 box               tilt large
 read_data         data.static

--- a/maml/apps/pes/templates/neb/in.neb
+++ b/maml/apps/pes/templates/neb/in.neb
@@ -2,7 +2,7 @@
 
 units           metal
 
-atom_style      charge
+atom_style      atomic
 atom_modify     map array
 boundary        p p p
 atom_modify	    sort 0 0.0

--- a/notebooks/pes/gap/example.ipynb
+++ b/notebooks/pes/gap/example.ipynb
@@ -199,47 +199,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Lattice constant, Elastic constant"
+    "# Lattice constant, Elastic constant\n",
+    "### Large error due to limited training data -- 10 structures"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Ni  C11:  294.00292058499 C12:  215.956808932469 C44:  172.632763694098\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from maml.apps.pes import ElasticConstant\n",
+    "from pymatgen.core import Lattice\n",
     "\n",
-    "Ni_ec_calculator = ElasticConstant(ff_settings=gap, lattice='fcc', alat=3.51, atom_type='Ni')\n",
-    "Ni_C11, Ni_C12, Ni_C44, _ = Ni_ec_calculator.calculate()\n",
-    "print('Ni', ' C11: ', Ni_C11, 'C12: ', Ni_C12, 'C44: ', Ni_C44)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mo  C11:  1178.51552223199 C12:  -428.408236874733 C44:  373.512164542\n"
-     ]
-    }
-   ],
-   "source": [
-    "Mo_ec_calculator = ElasticConstant(ff_settings=gap, lattice='bcc', alat=3.17, atom_type='Mo')\n",
-    "Mo_C11, Mo_C12, Mo_C44, _ = Mo_ec_calculator.calculate()\n",
-    "print('Mo', ' C11: ', Mo_C11, 'C12: ', Mo_C12, 'C44: ', Mo_C44)"
+    "Ni = Structure.from_spacegroup(sg='Fm-3m', species=['Ni'], lattice=Lattice.cubic(3.51), coords=[[0, 0, 0]])\n",
+    "Mo = Structure.from_spacegroup(sg='Im-3m', species=['Mo'], lattice=Lattice.cubic(3.17), coords=[[0, 0, 0]])"
    ]
   },
   {
@@ -256,7 +229,6 @@
     }
    ],
    "source": [
-    "from pymatgen import Lattice\n",
     "from maml.apps.pes import LatticeConstant\n",
     "\n",
     "Ni = Structure.from_spacegroup(sg='Fm-3m', species=['Ni'], lattice=Lattice.cubic(3.51), coords=[[0, 0, 0]])\n",
@@ -283,6 +255,46 @@
     "lc_calculator = LatticeConstant(ff_settings=gap)\n",
     "a, b, c = lc_calculator.calculate([Mo])[0]\n",
     "print('Mo', 'Lattice a: {}, Lattice b: {}, Lattice c: {}'.format(a, b, c))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ni  C11:  294.00292058499 C12:  215.956808932469 C44:  172.632763694098\n"
+     ]
+    }
+   ],
+   "source": [
+    "from maml.apps.pes import ElasticConstant\n",
+    "\n",
+    "Ni_ec_calculator = ElasticConstant(ff_settings=gap)\n",
+    "Ni_C11, Ni_C12, Ni_C44, _ = Ni_ec_calculator.calculate([Ni])[0]\n",
+    "print('Ni', ' C11: ', Ni_C11, 'C12: ', Ni_C12, 'C44: ', Ni_C44)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mo  C11:  1178.51552223199 C12:  -428.408236874733 C44:  373.512164542\n"
+     ]
+    }
+   ],
+   "source": [
+    "Mo_ec_calculator = ElasticConstant(ff_settings=gap)\n",
+    "Mo_C11, Mo_C12, Mo_C44, _ = Mo_ec_calculator.calculate([Mo])[0]\n",
+    "print('Mo', ' C11: ', Mo_C11, 'C12: ', Mo_C12, 'C44: ', Mo_C44)"
    ]
   },
   {
@@ -498,7 +510,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/pes/mtp/example.ipynb
+++ b/notebooks/pes/mtp/example.ipynb
@@ -221,27 +221,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "INFO:maml.apps.pes._lammps:Setting Lammps executable to lmp_g++_serial\n",
       "INFO:maml.apps.pes._lammps:Setting Lammps executable to lmp_g++_serial\n"
      ]
     },
     {
-     "ename": "ValueError",
-     "evalue": "unexpected '{' in field name",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-22-2bfaaf947bd4>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0mNi_ec_calculator\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mElasticConstant\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mff_settings\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmtp_loaded\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m \u001b[0mNi_C11\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mNi_C12\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mNi_C44\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0m_\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mNi_ec_calculator\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcalculate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mNi\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      5\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Ni'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m' C11: '\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mNi_C11\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'C12: '\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mNi_C12\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'C44: '\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mNi_C44\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/repos/maml/maml/apps/pes/_lammps.py\u001b[0m in \u001b[0;36mcalculate\u001b[0;34m(self, structures)\u001b[0m\n\u001b[1;32m    136\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    137\u001b[0m         \u001b[0;32mwith\u001b[0m \u001b[0mScratchDir\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\".\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 138\u001b[0;31m             \u001b[0minput_file\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_setup\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    139\u001b[0m             \u001b[0mdata\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    140\u001b[0m             \u001b[0;32mfor\u001b[0m \u001b[0mstruct\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mstructures\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/repos/maml/maml/apps/pes/_lammps.py\u001b[0m in \u001b[0;36m_setup\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    433\u001b[0m         \u001b[0minput_file\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"in.elastic\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    434\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mff_settings\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mPotential\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 435\u001b[0;31m             \u001b[0mff_settings\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mff_settings\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwrite_param\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    436\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    437\u001b[0m             \u001b[0mff_settings\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mff_settings\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mValueError\u001b[0m: unexpected '{' in field name"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ni  C11:  543.18248948548 C12:  506.8766660057 C44:  63.1820936905847\n",
+      "Mo  C11:  687.416829999536 C12:  848.638068500906 C44:  -117.680068651214\n"
      ]
     }
    ],

--- a/notebooks/pes/mtp/example.ipynb
+++ b/notebooks/pes/mtp/example.ipynb
@@ -221,23 +221,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:maml.apps.pes._lammps:Setting Lammps executable to lmp_g++_serial\n",
       "INFO:maml.apps.pes._lammps:Setting Lammps executable to lmp_g++_serial\n"
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Ni  C11:  543.18248948548 C12:  506.8766660057 C44:  63.1820936905847\n",
-      "Mo  C11:  687.416829999536 C12:  848.638068500906 C44:  -117.680068651214\n"
+     "ename": "ValueError",
+     "evalue": "unexpected '{' in field name",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-22-2bfaaf947bd4>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0mNi_ec_calculator\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mElasticConstant\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mff_settings\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmtp_loaded\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m \u001b[0mNi_C11\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mNi_C12\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mNi_C44\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0m_\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mNi_ec_calculator\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcalculate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mNi\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      5\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Ni'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m' C11: '\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mNi_C11\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'C12: '\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mNi_C12\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'C44: '\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mNi_C44\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/repos/maml/maml/apps/pes/_lammps.py\u001b[0m in \u001b[0;36mcalculate\u001b[0;34m(self, structures)\u001b[0m\n\u001b[1;32m    136\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    137\u001b[0m         \u001b[0;32mwith\u001b[0m \u001b[0mScratchDir\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\".\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 138\u001b[0;31m             \u001b[0minput_file\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_setup\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    139\u001b[0m             \u001b[0mdata\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    140\u001b[0m             \u001b[0;32mfor\u001b[0m \u001b[0mstruct\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mstructures\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/repos/maml/maml/apps/pes/_lammps.py\u001b[0m in \u001b[0;36m_setup\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    433\u001b[0m         \u001b[0minput_file\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"in.elastic\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    434\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mff_settings\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mPotential\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 435\u001b[0;31m             \u001b[0mff_settings\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mff_settings\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwrite_param\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    436\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    437\u001b[0m             \u001b[0mff_settings\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mff_settings\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: unexpected '{' in field name"
      ]
     }
    ],

--- a/notebooks/pes/mtp/example.ipynb
+++ b/notebooks/pes/mtp/example.ipynb
@@ -13,7 +13,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pymatgen import Structure\n",
+    "from pymatgen.core import Structure\n",
     "from monty.serialization import loadfn\n",
     "\n",
     "data = loadfn('data.json')\n",
@@ -33,6 +33,17 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from maml.apps.pes import MTPotential\n",
+    "\n",
+    "mtp = MTPotential()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -57,16 +68,12 @@
        "0"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "from maml.apps.pes import MTPotential\n",
-    "\n",
-    "mtp = MTPotential()\n",
-    "\n",
     "mtp.train(train_structures=train_structures, train_energies=train_energies,\n",
     "          train_forces=train_forces, train_stresses = None, max_dist=5, stress_weight=0)"
    ]
@@ -137,20 +144,58 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Lattice constants and eslastic constants"
+    "# Write and load fitted mtp with parameters files"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mtp_write = mtp.write_param()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mtp_loaded = MTPotential.from_config(filename='fitted.mtp', elements=[\"Ni\", \"Mo\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Lattice constants and eslastic constants\n",
+    "### Large error due to limited training data -- 10 structures"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pymatgen.core import Lattice\n",
+    "\n",
+    "Ni = Structure.from_spacegroup(sg='Fm-3m', species=['Ni'], lattice=Lattice.cubic(3.51), coords=[[0, 0, 0]])\n",
+    "Mo = Structure.from_spacegroup(sg='Im-3m', species=['Mo'], lattice=Lattice.cubic(3.17), coords=[[0, 0, 0]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:maml.apps.pes._lammps:Setting Lammps executable to lmp_intel_cpu_intelmpi\n",
-      "INFO:maml.apps.pes._lammps:Setting Lammps executable to lmp_intel_cpu_intelmpi\n"
+      "INFO:maml.apps.pes._lammps:Setting Lammps executable to lmp_g++_serial\n",
+      "INFO:maml.apps.pes._lammps:Setting Lammps executable to lmp_g++_serial\n"
      ]
     },
     {
@@ -163,70 +208,49 @@
     }
    ],
    "source": [
-    "from pymatgen import Lattice\n",
     "from maml.apps.pes import LatticeConstant\n",
     "\n",
-    "Ni = Structure.from_spacegroup(sg='Fm-3m', species=['Ni'], lattice=Lattice.cubic(3.51), coords=[[0, 0, 0]])\n",
-    "lc_calculator = LatticeConstant(ff_settings=mtp)\n",
+    "lc_calculator = LatticeConstant(ff_settings=mtp_loaded)\n",
     "a, b, c = lc_calculator.calculate([Ni])[0]\n",
     "print('Ni', 'Lattice a: {}, Lattice b: {}, Lattice c: {}'.format(a, b, c))\n",
     "\n",
-    "Mo = Structure.from_spacegroup(sg='Im-3m', species=['Mo'], lattice=Lattice.cubic(3.17), coords=[[0, 0, 0]])\n",
-    "lc_calculator = LatticeConstant(ff_settings=mtp)\n",
+    "lc_calculator = LatticeConstant(ff_settings=mtp_loaded)\n",
     "a, b, c = lc_calculator.calculate([Mo])[0]\n",
     "print('Mo', 'Lattice a: {}, Lattice b: {}, Lattice c: {}'.format(a, b, c))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:maml.apps.pes._lammps:Setting Lammps executable to lmp_intel_cpu_intelmpi\n",
-      "INFO:maml.apps.pes._lammps:Setting Lammps executable to lmp_intel_cpu_intelmpi\n"
+      "INFO:maml.apps.pes._lammps:Setting Lammps executable to lmp_g++_serial\n",
+      "INFO:maml.apps.pes._lammps:Setting Lammps executable to lmp_g++_serial\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Ni  C11:  543.182489508763 C12:  506.876665737945 C44:  63.1820936829429\n",
-      "Mo  C11:  63726531.095037 C12:  8776445.070753 C44:  -13925417.1625812\n"
+      "Ni  C11:  543.18248948548 C12:  506.8766660057 C44:  63.1820936905847\n",
+      "Mo  C11:  687.416829999536 C12:  848.638068500906 C44:  -117.680068651214\n"
      ]
     }
    ],
    "source": [
     "from maml.apps.pes import ElasticConstant\n",
     "\n",
-    "Ni_ec_calculator = ElasticConstant(ff_settings=mtp, lattice='fcc', alat=3.51, atom_type='Ni')\n",
-    "Ni_C11, Ni_C12, Ni_C44, _ = Ni_ec_calculator.calculate()\n",
+    "Ni_ec_calculator = ElasticConstant(ff_settings=mtp_loaded)\n",
+    "Ni_C11, Ni_C12, Ni_C44, _ = Ni_ec_calculator.calculate([Ni])[0]\n",
     "print('Ni', ' C11: ', Ni_C11, 'C12: ', Ni_C12, 'C44: ', Ni_C44)\n",
     "\n",
-    "Mo_ec_calculator = ElasticConstant(ff_settings=mtp, lattice='bcc', alat=3.17, atom_type='Mo')\n",
-    "Mo_C11, Mo_C12, Mo_C44, _ = Mo_ec_calculator.calculate()\n",
+    "Mo_ec_calculator = ElasticConstant(ff_settings=mtp_loaded)\n",
+    "Mo_C11, Mo_C12, Mo_C44, _ = Mo_ec_calculator.calculate([Mo])[0]\n",
     "print('Mo', ' C11: ', Mo_C11, 'C12: ', Mo_C12, 'C44: ', Mo_C44)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Write and load fitted mtp with parameters files"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mtp_write = mtp.write_param()\n",
-    "\n",
-    "mtp_loaded = MTPotential.from_config(filename='fitted.mtp', elements=[\"Ni\", \"Mo\"])"
    ]
   },
   {

--- a/notebooks/pes/nnp/example.ipynb
+++ b/notebooks/pes/nnp/example.ipynb
@@ -414,47 +414,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Lattice constant, Elastic constant"
+    "# Lattice constant, Elastic constant\n",
+    "### Large error due to limited training data -- 10 structures"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Ni  C11:  245.464447449194 C12:  72.2672717252862 C44:  201.597098446191\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from maml.apps.pes import ElasticConstant\n",
+    "from pymatgen.core import Lattice\n",
     "\n",
-    "Ni_ec_calculator = ElasticConstant(ff_settings=nnp, lattice='fcc', alat=3.51, atom_type='Ni')\n",
-    "Ni_C11, Ni_C12, Ni_C44, _ = Ni_ec_calculator.calculate()\n",
-    "print('Ni', ' C11: ', Ni_C11, 'C12: ', Ni_C12, 'C44: ', Ni_C44)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mo  C11:  23914.7973436972 C12:  755.4018514041 C44:  -0.416647311230344\n"
-     ]
-    }
-   ],
-   "source": [
-    "Mo_ec_calculator = ElasticConstant(ff_settings=nnp, lattice='bcc', alat=3.17, atom_type='Mo')\n",
-    "Mo_C11, Mo_C12, Mo_C44, _ = Mo_ec_calculator.calculate()\n",
-    "print('Mo', ' C11: ', Mo_C11, 'C12: ', Mo_C12, 'C44: ', Mo_C44)"
+    "Ni = Structure.from_spacegroup(sg='Fm-3m', species=['Ni'], lattice=Lattice.cubic(3.51), coords=[[0, 0, 0]])\n",
+    "Mo = Structure.from_spacegroup(sg='Im-3m', species=['Mo'], lattice=Lattice.cubic(3.17), coords=[[0, 0, 0]])"
    ]
   },
   {
@@ -471,10 +444,8 @@
     }
    ],
    "source": [
-    "from pymatgen import Lattice\n",
     "from maml.apps.pes import LatticeConstant\n",
     "\n",
-    "Ni = Structure.from_spacegroup(sg='Fm-3m', species=['Ni'], lattice=Lattice.cubic(3.51), coords=[[0, 0, 0]])\n",
     "lc_calculator = LatticeConstant(ff_settings=nnp)\n",
     "a, b, c = lc_calculator.calculate([Ni])[0]\n",
     "print('Ni', 'Lattice a: {}, Lattice b: {}, Lattice c: {}'.format(a, b, c))"
@@ -494,10 +465,49 @@
     }
    ],
    "source": [
-    "Mo = Structure.from_spacegroup(sg='Im-3m', species=['Mo'], lattice=Lattice.cubic(3.17), coords=[[0, 0, 0]])\n",
     "lc_calculator = LatticeConstant(ff_settings=nnp)\n",
     "a, b, c = lc_calculator.calculate([Mo])[0]\n",
     "print('Mo', 'Lattice a: {}, Lattice b: {}, Lattice c: {}'.format(a, b, c))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ni  C11:  245.464447449194 C12:  72.2672717252862 C44:  201.597098446191\n"
+     ]
+    }
+   ],
+   "source": [
+    "from maml.apps.pes import ElasticConstant\n",
+    "\n",
+    "Ni_ec_calculator = ElasticConstant(ff_settings=nnp)\n",
+    "Ni_C11, Ni_C12, Ni_C44, _ = Ni_ec_calculator.calculate([Ni])[0]\n",
+    "print('Ni', ' C11: ', Ni_C11, 'C12: ', Ni_C12, 'C44: ', Ni_C44)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mo  C11:  23914.7973436972 C12:  755.4018514041 C44:  -0.416647311230344\n"
+     ]
+    }
+   ],
+   "source": [
+    "Mo_ec_calculator = ElasticConstant(ff_settings=nnp)\n",
+    "Mo_C11, Mo_C12, Mo_C44, _ = Mo_ec_calculator.calculate([Mo])[0]\n",
+    "print('Mo', ' C11: ', Mo_C11, 'C12: ', Mo_C12, 'C44: ', Mo_C44)"
    ]
   },
   {
@@ -725,7 +735,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/pes/qsnap/example.ipynb
+++ b/notebooks/pes/qsnap/example.ipynb
@@ -9,13 +9,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 3,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "from pymatgen import Structure\n",
+    "from pymatgen.core import Structure\n",
     "from monty.serialization import loadfn\n",
     "\n",
     "data = loadfn('data.json')\n",
@@ -222,7 +220,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Lattice constant, Elastic constant"
+    "# Lattice constant, Elastic constant\n",
+    "### Large error due to limited training data -- 10 structures"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pymatgen.core import Lattice\n",
+    "\n",
+    "Ni = Structure.from_spacegroup(sg='Fm-3m', species=['Ni'], lattice=Lattice.cubic(3.51), coords=[[0, 0, 0]])\n",
+    "Mo = Structure.from_spacegroup(sg='Im-3m', species=['Mo'], lattice=Lattice.cubic(3.17), coords=[[0, 0, 0]])"
    ]
   },
   {
@@ -241,8 +252,8 @@
    "source": [
     "from maml.apps.pes import ElasticConstant\n",
     "\n",
-    "Ni_ec_calculator = ElasticConstant(ff_settings=qsnap, lattice='fcc', alat=3.51, atom_type='Ni')\n",
-    "Ni_C11, Ni_C12, Ni_C44, _ = Ni_ec_calculator.calculate()\n",
+    "Ni_ec_calculator = ElasticConstant(ff_settings=qsnap)\n",
+    "Ni_C11, Ni_C12, Ni_C44, _ = Ni_ec_calculator.calculate([Ni])[0]\n",
     "print('Ni', ' C11: ', Ni_C11, 'C12: ', Ni_C12, 'C44: ', Ni_C44)"
    ]
   },
@@ -260,8 +271,8 @@
     }
    ],
    "source": [
-    "Mo_ec_calculator = ElasticConstant(ff_settings=qsnap, lattice='bcc', alat=3.17, atom_type='Mo')\n",
-    "Mo_C11, Mo_C12, Mo_C44, _ = Mo_ec_calculator.calculate()\n",
+    "Mo_ec_calculator = ElasticConstant(ff_settings=qsnap)\n",
+    "Mo_C11, Mo_C12, Mo_C44, _ = Mo_ec_calculator.calculate([Mo])[0]\n",
     "print('Mo', ' C11: ', Mo_C11, 'C12: ', Mo_C12, 'C44: ', Mo_C44)"
    ]
   },
@@ -489,7 +500,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/pes/qsnap/example_with_stress.ipynb
+++ b/notebooks/pes/qsnap/example_with_stress.ipynb
@@ -141,7 +141,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Lattice constants, Elastic constant"
+    "# Lattice constants, Elastic constant\n",
+    "### Large error due to limited training data -- 10 structures"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pymatgen.core import Lattice\n",
+    "\n",
+    "Ni = Structure.from_spacegroup(sg='Fm-3m', species=['Ni'], lattice=Lattice.cubic(3.51), coords=[[0, 0, 0]])\n",
+    "Mo = Structure.from_spacegroup(sg='Im-3m', species=['Mo'], lattice=Lattice.cubic(3.17), coords=[[0, 0, 0]])"
    ]
   },
   {
@@ -167,8 +180,8 @@
    "source": [
     "from maml.apps.pes import ElasticConstant\n",
     "\n",
-    "Ni_ec_calculator = ElasticConstant(ff_settings=qsnap, lattice='fcc', alat=3.51, atom_type='Ni')\n",
-    "Ni_C11, Ni_C12, Ni_C44, _ = Ni_ec_calculator.calculate()\n",
+    "Ni_ec_calculator = ElasticConstant(ff_settings=qsnap)\n",
+    "Ni_C11, Ni_C12, Ni_C44, _ = Ni_ec_calculator.calculate([Ni])[0]\n",
     "print('Ni', ' C11: ', Ni_C11, 'C12: ', Ni_C12, 'C44: ', Ni_C44)"
    ]
   },
@@ -193,17 +206,10 @@
     }
    ],
    "source": [
-    "Mo_ec_calculator = ElasticConstant(ff_settings=qsnap, lattice='bcc', alat=3.17, atom_type='Mo')\n",
-    "Mo_C11, Mo_C12, Mo_C44, _ = Mo_ec_calculator.calculate()\n",
+    "Mo_ec_calculator = ElasticConstant(ff_settings=qsnap)\n",
+    "Mo_C11, Mo_C12, Mo_C44, _ = Mo_ec_calculator.calculate([Mo])[0]\n",
     "print('Mo', ' C11: ', Mo_C11, 'C12: ', Mo_C12, 'C44: ', Mo_C44)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -222,7 +228,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/pes/snap/example.ipynb
+++ b/notebooks/pes/snap/example.ipynb
@@ -222,47 +222,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Lattice constant, Elastic constant"
+    "# Lattice constant, Elastic constant\n",
+    "### Large error due to limited training data -- 10 structures"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Ni  C11:  159.82034045317 C12:  236.570065272579 C44:  55.2780305678332\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from maml.apps.pes import ElasticConstant\n",
-    "\n",
-    "Ni_ec_calculator = ElasticConstant(ff_settings=snap, lattice='fcc', alat=3.51, atom_type='Ni')\n",
-    "Ni_C11, Ni_C12, Ni_C44, _ = Ni_ec_calculator.calculate()\n",
-    "print('Ni', ' C11: ', Ni_C11, 'C12: ', Ni_C12, 'C44: ', Ni_C44)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mo  C11:  -0.999219759978588 C12:  108.341414925053 C44:  5.06105663592628\n"
-     ]
-    }
-   ],
-   "source": [
-    "Mo_ec_calculator = ElasticConstant(ff_settings=snap, lattice='bcc', alat=3.17, atom_type='Mo')\n",
-    "Mo_C11, Mo_C12, Mo_C44, _ = Mo_ec_calculator.calculate()\n",
-    "print('Mo', ' C11: ', Mo_C11, 'C12: ', Mo_C12, 'C44: ', Mo_C44)"
+    "from pymatgen.core import Lattice\n",
+    "Ni = Structure.from_spacegroup(sg='Fm-3m', species=['Ni'], lattice=Lattice.cubic(3.51), coords=[[0, 0, 0]])\n",
+    "Mo = Structure.from_spacegroup(sg='Im-3m', species=['Mo'], lattice=Lattice.cubic(3.17), coords=[[0, 0, 0]])"
    ]
   },
   {
@@ -279,7 +251,6 @@
     }
    ],
    "source": [
-    "from pymatgen import Lattice\n",
     "from maml.apps.pes import LatticeConstant\n",
     "\n",
     "Ni = Structure.from_spacegroup(sg='Fm-3m', species=['Ni'], lattice=Lattice.cubic(3.51), coords=[[0, 0, 0]])\n",
@@ -302,10 +273,49 @@
     }
    ],
    "source": [
-    "Mo = Structure.from_spacegroup(sg='Im-3m', species=['Mo'], lattice=Lattice.cubic(3.17), coords=[[0, 0, 0]])\n",
     "lc_calculator = LatticeConstant(ff_settings=snap)\n",
     "a, b, c = lc_calculator.calculate([Mo])[0]\n",
     "print('Mo', 'Lattice a: {}, Lattice b: {}, Lattice c: {}'.format(a, b, c))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ni  C11:  159.82034045317 C12:  236.570065272579 C44:  55.2780305678332\n"
+     ]
+    }
+   ],
+   "source": [
+    "from maml.apps.pes import ElasticConstant\n",
+    "\n",
+    "Ni_ec_calculator = ElasticConstant(ff_settings=snap)\n",
+    "Ni_C11, Ni_C12, Ni_C44, _ = Ni_ec_calculator.calculate([Ni])[0]\n",
+    "print('Ni', ' C11: ', Ni_C11, 'C12: ', Ni_C12, 'C44: ', Ni_C44)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mo  C11:  -0.999219759978588 C12:  108.341414925053 C44:  5.06105663592628\n"
+     ]
+    }
+   ],
+   "source": [
+    "Mo_ec_calculator = ElasticConstant(ff_settings=snap)\n",
+    "Mo_C11, Mo_C12, Mo_C44, _ = Mo_ec_calculator.calculate([Mo])[0]\n",
+    "print('Mo', ' C11: ', Mo_C11, 'C12: ', Mo_C12, 'C44: ', Mo_C44)"
    ]
   },
   {
@@ -583,7 +593,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/pes/snap/example_with_stress.ipynb
+++ b/notebooks/pes/snap/example_with_stress.ipynb
@@ -260,61 +260,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Lattice constants, Elastic constant"
+    "# Lattice constants, Elastic constant\n",
+    "### Large error due to limited training data -- 10 structures"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:maml.apps.pes._lammps:Setting Lammps executable to lmp_serial\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Ni  C11:  314.169856583909 C12:  308.660699662111 C44:  69.7476168000187\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from maml.apps.pes import ElasticConstant\n",
+    "from pymatgen.core import Lattice\n",
     "\n",
-    "Ni_ec_calculator = ElasticConstant(ff_settings=snap, lattice='fcc', alat=3.51, atom_type='Ni')\n",
-    "Ni_C11, Ni_C12, Ni_C44, _ = Ni_ec_calculator.calculate()\n",
-    "print('Ni', ' C11: ', Ni_C11, 'C12: ', Ni_C12, 'C44: ', Ni_C44)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:maml.apps.pes._lammps:Setting Lammps executable to lmp_serial\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mo  C11:  33.0332580471668 C12:  129.122105036582 C44:  4.45521235633949\n"
-     ]
-    }
-   ],
-   "source": [
-    "Mo_ec_calculator = ElasticConstant(ff_settings=snap, lattice='bcc', alat=3.17, atom_type='Mo')\n",
-    "Mo_C11, Mo_C12, Mo_C44, _ = Mo_ec_calculator.calculate()\n",
-    "print('Mo', ' C11: ', Mo_C11, 'C12: ', Mo_C12, 'C44: ', Mo_C44)"
+    "Ni = Structure.from_spacegroup(sg='Fm-3m', species=['Ni'], lattice=Lattice.cubic(3.51), coords=[[0, 0, 0]])\n",
+    "Mo = Structure.from_spacegroup(sg='Im-3m', species=['Mo'], lattice=Lattice.cubic(3.17), coords=[[0, 0, 0]])"
    ]
   },
   {
@@ -338,10 +297,8 @@
     }
    ],
    "source": [
-    "from pymatgen import Lattice\n",
     "from maml.apps.pes import LatticeConstant\n",
     "\n",
-    "Ni = Structure.from_spacegroup(sg='Fm-3m', species=['Ni'], lattice=Lattice.cubic(3.51), coords=[[0, 0, 0]])\n",
     "lc_calculator = LatticeConstant(ff_settings=snap)\n",
     "a, b, c = lc_calculator.calculate([Ni])[0]\n",
     "print('Ni', 'Lattice a: {}, Lattice b: {}, Lattice c: {}'.format(a, b, c))"
@@ -368,10 +325,63 @@
     }
    ],
    "source": [
-    "Mo = Structure.from_spacegroup(sg='Im-3m', species=['Mo'], lattice=Lattice.cubic(3.17), coords=[[0, 0, 0]])\n",
     "lc_calculator = LatticeConstant(ff_settings=snap)\n",
     "a, b, c = lc_calculator.calculate([Mo])[0]\n",
     "print('Mo', 'Lattice a: {}, Lattice b: {}, Lattice c: {}'.format(a, b, c))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:maml.apps.pes._lammps:Setting Lammps executable to lmp_serial\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ni  C11:  314.169856583909 C12:  308.660699662111 C44:  69.7476168000187\n"
+     ]
+    }
+   ],
+   "source": [
+    "from maml.apps.pes import ElasticConstant\n",
+    "\n",
+    "Ni_ec_calculator = ElasticConstant(ff_settings=snap)\n",
+    "Ni_C11, Ni_C12, Ni_C44, _ = Ni_ec_calculator.calculate()\n",
+    "print('Ni', ' C11: ', Ni_C11, 'C12: ', Ni_C12, 'C44: ', Ni_C44)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:maml.apps.pes._lammps:Setting Lammps executable to lmp_serial\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mo  C11:  33.0332580471668 C12:  129.122105036582 C44:  4.45521235633949\n"
+     ]
+    }
+   ],
+   "source": [
+    "Mo_ec_calculator = ElasticConstant(ff_settings=snap)\n",
+    "Mo_C11, Mo_C12, Mo_C44, _ = Mo_ec_calculator.calculate()\n",
+    "print('Mo', ' C11: ', Mo_C11, 'C12: ', Mo_C12, 'C44: ', Mo_C44)"
    ]
   }
  ],
@@ -391,7 +401,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
1. Enable calculator to return elastic tensor in 6x6 Voigt notation. The default is still to return C11, C12, C44 and bulk modulus. This is controlled by full_matrix argument when initializing the calculator.

2. Only allow input structures by structure list, instead of lattice types and parameters. 
- This is consistent with lattice constant calculator.
- Structure list can fully cover all possible cases.
- Previous lattice types only allow structure types with single lattice parameters (a=b=c), like bcc, fcc, diamond. This is quite limited.
- I have modified all notebooks about this change.