### PR TITLE
Some fix for NEB and Defect calculators

### DIFF
--- a/maml/apps/pes/_lammps.py
+++ b/maml/apps/pes/_lammps.py
@@ -599,7 +599,9 @@ class NudgedElasticBand(LMPStaticCalculator):
             raise ValueError("Lattice type is invalid.")
 
         super_cell = unit_cell * scale_factor
-        super_cell_ld = LammpsData.from_structure(super_cell, ff_elements=self.ff_settings.elements)
+        super_cell_ld = LammpsData.from_structure(
+            super_cell, ff_elements=self.ff_settings.elements, atom_style="atomic"
+        )
         super_cell_ld.write_file("data.supercell")
 
         with open("in.relax", "w") as f:
@@ -652,7 +654,7 @@ class NudgedElasticBand(LMPStaticCalculator):
                 error_msg += msg[-1]
             raise RuntimeError(error_msg)
 
-        final_relaxed_struct = LammpsData.from_file("final.relaxed", atom_style="charge").structure
+        final_relaxed_struct = LammpsData.from_file("final.relaxed", atom_style="atomic").structure
 
         lines = ["{}".format(final_relaxed_struct.num_sites)]
 
@@ -690,10 +692,9 @@ class NudgedElasticBand(LMPStaticCalculator):
             with subprocess.Popen(
                 [
                     "mpirun",
-                    "--oversubscribe",
                     "-n",
                     str(self.num_replicas),
-                    "lmp_mpi",
+                    self.LMP_EXE,
                     "-partition",
                     "{}x1".format(self.num_replicas),
                     "-in",
@@ -806,7 +807,9 @@ class DefectFormation(LMPStaticCalculator):
         efs_calculator = EnergyForceStress(ff_settings=self.ff_settings)
         energy_per_atom = efs_calculator.calculate([super_cell])[0][0] / len(super_cell)
 
-        super_cell_ld = LammpsData.from_structure(super_cell, ff_elements=self.ff_settings.elements)
+        super_cell_ld = LammpsData.from_structure(
+            super_cell, ff_elements=self.ff_settings.elements, atom_style="atomic"
+        )
         super_cell_ld.write_file("data.supercell")
 
         input_file = "in.defect"

--- a/maml/apps/pes/templates/neb/in.relax
+++ b/maml/apps/pes/templates/neb/in.relax
@@ -2,7 +2,7 @@
 
 units           metal
 
-atom_style      charge
+atom_style      atomic
 atom_modify     map array
 boundary        p p p
 atom_modify	sort 0 0.0


### PR DESCRIPTION
The data.lammps files with `atom_style=charge` generated by pymatgen was not readable by lammps for some reason. (Researchers from UCB are working on this part of pymatgen) I'm using `atomic` as the `atom_style` consistently in maml. With this current _lammps.py, I reproduced the vacancy formation energy and migration energy calculated by SNAP in Yunxing's paper.

Like the previous `ElasticConstant` calculator, the current `NudgedElasticBand` calculator and `DefectFormation` calculator take `species`, `lattice` and `alat` information as input, and the site to remove is fixed. The usage is limited to elements with `fcc`, `bcc` or `diamond` lattice. It can be extended to compound, and choosing site to remove can be enabled, by defining a new function called `_setup_from_structure`, so that the previous operations won't be affected. I haven't worked on it as I'm working on elements. Please let me know if you got any suggestion on this part. Thanks! 😄