### PR TITLE
fix site_describer.ipynb import error

### DIFF
--- a/notebooks/describer/site_describer.ipynb
+++ b/notebooks/describer/site_describer.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pymatgen import Structure, Lattice\n",
+    "from pymatgen.core import Structure, Lattice\n",
     "\n",
     "s = Structure(Lattice.cubic(3.147), ['Mo', 'Mo'], \n",
     "              [[0, 0, 0], [0.5, 0.5, 0.5]])  # a simple Mo bcc lattice"
@@ -389,7 +389,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
1. Fix the import error in site_descirber.ipynb

>  from pymatgen import Structure, Lattice
to
> from pymatgen.core import Structure, Lattice