### PR TITLE
Update garnet_formation_energy.ipynb

### DIFF
--- a/notebooks/model/garnet_formation_energy.ipynb
+++ b/notebooks/model/garnet_formation_energy.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "from pymatgen import Structure\n",
+    "from pymatgen.core import Structure\n",
     "\n",
     "from maml.describers import DistinctSiteProperty\n",
     "from maml.models import SKLModel\n",


### PR DESCRIPTION
Fixes #355

Fixes Import issue 

Changes:
```diff
- from pymatgen import Structure
+ from pymatgen.core import Structure
```

**Code execution**

```
>>> import pandas as pd
>>> from pymatgen import Structure
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'Structure' from 'pymatgen' (unknown location)
>>>
>>> from pymatgen.core import Structure
>>>
```