### PR TITLE
Clarify the logger message of BirchClustering

### DIFF
--- a/maml/sampling/clustering.py
+++ b/maml/sampling/clustering.py
@@ -58,16 +58,30 @@ class BirchClustering(BaseEstimator, TransformerMixin):
             PCA feature, centroid positions of each cluster in PCA feature s
             pace, and the array of input PCA features.
         """
-        model = Birch(n_clusters=self.n, threshold=self.threshold_init, **self.kwargs).fit(PCAfeatures)
+        model = Birch(
+            n_clusters=self.n, threshold=self.threshold_init, **self.kwargs
+        ).fit(PCAfeatures)
         if self.n is not None:
-            while len(model.subcluster_labels_) < self.n:  # decrease threshold until desired n clusters is achieved
-                logger.info(f"Birch threshold of {self.threshold_init} gives {len(model.subcluster_labels_)} clusters.")
-                self.threshold_init = self.threshold_init / self.n * len(model.subcluster_labels_)
-                model = Birch(n_clusters=self.n, threshold=self.threshold_init, **self.kwargs).fit(PCAfeatures)
+            while (
+                len(set(model.subcluster_labels_)) < self.n
+            ):  # decrease threshold until desired n clusters is achieved
+                logger.info(
+                    f"BirchClustering with threshold_init={self.threshold_init} and n={self.n} "
+                    f"gives {len(set(model.subcluster_labels_))} clusters.",
+                )
+                self.threshold_init = (
+                    self.threshold_init / self.n * len(set(model.subcluster_labels_))
+                )
+                model = Birch(
+                    n_clusters=self.n, threshold=self.threshold_init, **self.kwargs
+                ).fit(PCAfeatures)
 
         labels = model.predict(PCAfeatures)
         self.model = model
-        logger.info(f"Birch threshold of {self.threshold_init} gives {len(model.subcluster_labels_)} clusters.")
+        logger.info(
+            f"BirchClustering with threshold_init={self.threshold_init} and n={self.n} "
+            f"gives {len(set(model.subcluster_labels_))} clusters.",
+        )
         label_centers = dict(zip(model.subcluster_labels_, model.subcluster_centers_))
         return {
             "labels": labels,

--- a/maml/sampling/clustering.py
+++ b/maml/sampling/clustering.py
@@ -58,9 +58,7 @@ class BirchClustering(BaseEstimator, TransformerMixin):
             PCA feature, centroid positions of each cluster in PCA feature s
             pace, and the array of input PCA features.
         """
-        model = Birch(
-            n_clusters=self.n, threshold=self.threshold_init, **self.kwargs
-        ).fit(PCAfeatures)
+        model = Birch(n_clusters=self.n, threshold=self.threshold_init, **self.kwargs).fit(PCAfeatures)
         if self.n is not None:
             while (
                 len(set(model.subcluster_labels_)) < self.n
@@ -69,12 +67,8 @@ class BirchClustering(BaseEstimator, TransformerMixin):
                     f"BirchClustering with threshold_init={self.threshold_init} and n={self.n} "
                     f"gives {len(set(model.subcluster_labels_))} clusters.",
                 )
-                self.threshold_init = (
-                    self.threshold_init / self.n * len(set(model.subcluster_labels_))
-                )
-                model = Birch(
-                    n_clusters=self.n, threshold=self.threshold_init, **self.kwargs
-                ).fit(PCAfeatures)
+                self.threshold_init = self.threshold_init / self.n * len(set(model.subcluster_labels_))
+                model = Birch(n_clusters=self.n, threshold=self.threshold_init, **self.kwargs).fit(PCAfeatures)
 
         labels = model.predict(PCAfeatures)
         self.model = model

--- a/notebooks/direct/Example1_MPF2021.2.8.all.ipynb
+++ b/notebooks/direct/Example1_MPF2021.2.8.all.ipynb
@@ -67,8 +67,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 454 ms, sys: 363 ms, total: 817 ms\n",
-      "Wall time: 1.14 s\n"
+      "CPU times: user 632 ms, sys: 304 ms, total: 936 ms\n",
+      "Wall time: 1.27 s\n"
      ]
     }
    ],
@@ -120,8 +120,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 19 µs, sys: 1 µs, total: 20 µs\n",
-      "Wall time: 20 µs\n"
+      "CPU times: user 28 µs, sys: 2 µs, total: 30 µs\n",
+      "Wall time: 33.6 µs\n"
      ]
     }
    ],
@@ -139,7 +139,7 @@
    "execution_count": 5,
    "id": "6ff0241a",
    "metadata": {
-    "scrolled": true
+    "scrolled": false
    },
    "outputs": [
     {
@@ -147,7 +147,7 @@
      "output_type": "stream",
      "text": [
       "INFO:maml.sampling.pca:Selected first 14 PCs, explaining 92.61% variance\n",
-      "INFO:maml.sampling.clustering:Birch threshold of 0.15 gives 21311 clusters.\n",
+      "INFO:maml.sampling.clustering:BirchClustering with threshold_init=0.15 and n=20050 gives 20050 clusters.\n",
       "INFO:maml.sampling.stratified_sampling:Finally selected 185670 configurations.\n"
      ]
     },
@@ -155,8 +155,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 5min 4s, sys: 8.35 s, total: 5min 13s\n",
-      "Wall time: 1min 16s\n"
+      "CPU times: user 7min, sys: 9.42 s, total: 7min 9s\n",
+      "Wall time: 1min 53s\n"
      ]
     }
    ],
@@ -301,7 +301,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/rr/d33n0r7d06zc3bfdcz58s0w00000gn/T/ipykernel_63383/1654159683.py:9: MatplotlibDeprecationWarning: The legendHandles attribute was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use legend_handles instead.\n",
+      "/var/folders/rr/d33n0r7d06zc3bfdcz58s0w00000gn/T/ipykernel_94543/2910446985.py:13: MatplotlibDeprecationWarning: The legendHandles attribute was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use legend_handles instead.\n",
       "  for lh in legend.legendHandles:\n"
      ]
     },
@@ -309,8 +309,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 166 ms, sys: 13.2 ms, total: 179 ms\n",
-      "Wall time: 59.6 ms\n"
+      "CPU times: user 140 ms, sys: 26.1 ms, total: 166 ms\n",
+      "Wall time: 101 ms\n"
      ]
     },
     {
@@ -341,7 +341,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/rr/d33n0r7d06zc3bfdcz58s0w00000gn/T/ipykernel_63383/1654159683.py:9: MatplotlibDeprecationWarning: The legendHandles attribute was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use legend_handles instead.\n",
+      "/var/folders/rr/d33n0r7d06zc3bfdcz58s0w00000gn/T/ipykernel_94543/2910446985.py:13: MatplotlibDeprecationWarning: The legendHandles attribute was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use legend_handles instead.\n",
       "  for lh in legend.legendHandles:\n"
      ]
     },
@@ -349,8 +349,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 42 ms, sys: 8.42 ms, total: 50.4 ms\n",
-      "Wall time: 49.2 ms\n"
+      "CPU times: user 61.4 ms, sys: 13.1 ms, total: 74.6 ms\n",
+      "Wall time: 73.3 ms\n"
      ]
     },
     {
@@ -420,8 +420,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 6.37 s, sys: 41.7 ms, total: 6.42 s\n",
-      "Wall time: 6.42 s\n"
+      "CPU times: user 8.98 s, sys: 98.9 ms, total: 9.08 s\n",
+      "Wall time: 9.23 s\n"
      ]
     }
    ],
@@ -441,7 +441,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x2dcf26670>"
+       "<matplotlib.legend.Legend at 0x2ffc12400>"
       ]
      },
      "execution_count": 16,

--- a/notebooks/direct/Example2_Ti-H.ipynb
+++ b/notebooks/direct/Example2_Ti-H.ipynb
@@ -79,8 +79,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 22.6 s, sys: 1.04 s, total: 23.6 s\n",
-      "Wall time: 7.7 s\n"
+      "CPU times: user 37.9 s, sys: 1.69 s, total: 39.6 s\n",
+      "Wall time: 15.7 s\n"
      ]
     }
    ],
@@ -107,8 +107,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.95 s, sys: 297 ms, total: 3.24 s\n",
-      "Wall time: 3.49 s\n"
+      "CPU times: user 3.61 s, sys: 358 ms, total: 3.97 s\n",
+      "Wall time: 4.5 s\n"
      ]
     }
    ],
@@ -130,7 +130,7 @@
      "output_type": "stream",
      "text": [
       "INFO:maml.sampling.pca:Selected first 8 PCs, explaining 97.66% variance\n",
-      "INFO:maml.sampling.clustering:Birch threshold of 0.05 gives 5769 clusters.\n",
+      "INFO:maml.sampling.clustering:BirchClustering with threshold_init=0.05 and n=1000 gives 1000 clusters.\n",
       "INFO:maml.sampling.stratified_sampling:Finally selected 1000 configurations.\n"
      ]
     },
@@ -138,8 +138,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 13min 40s, sys: 2min 21s, total: 16min 1s\n",
-      "Wall time: 9min 44s\n"
+      "CPU times: user 14min 22s, sys: 2min 55s, total: 17min 18s\n",
+      "Wall time: 11min 34s\n"
      ]
     }
    ],
@@ -223,15 +223,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 25.1 ms, sys: 1.94 ms, total: 27.1 ms\n",
-      "Wall time: 8.59 ms\n"
+      "CPU times: user 37.1 ms, sys: 3.2 ms, total: 40.3 ms\n",
+      "Wall time: 13.7 ms\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/rr/d33n0r7d06zc3bfdcz58s0w00000gn/T/ipykernel_23148/745124701.py:9: MatplotlibDeprecationWarning: The legendHandles attribute was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use legend_handles instead.\n",
+      "/var/folders/rr/d33n0r7d06zc3bfdcz58s0w00000gn/T/ipykernel_94549/1745198056.py:13: MatplotlibDeprecationWarning: The legendHandles attribute was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use legend_handles instead.\n",
       "  for lh in legend.legendHandles:\n"
      ]
     },
@@ -282,15 +282,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 22.5 ms, sys: 1.9 ms, total: 24.4 ms\n",
-      "Wall time: 7.63 ms\n"
+      "CPU times: user 28.7 ms, sys: 1.93 ms, total: 30.6 ms\n",
+      "Wall time: 9.4 ms\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/rr/d33n0r7d06zc3bfdcz58s0w00000gn/T/ipykernel_23148/745124701.py:9: MatplotlibDeprecationWarning: The legendHandles attribute was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use legend_handles instead.\n",
+      "/var/folders/rr/d33n0r7d06zc3bfdcz58s0w00000gn/T/ipykernel_94549/1745198056.py:13: MatplotlibDeprecationWarning: The legendHandles attribute was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use legend_handles instead.\n",
       "  for lh in legend.legendHandles:\n"
      ]
     },
@@ -373,8 +373,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 136 ms, sys: 832 µs, total: 137 ms\n",
-      "Wall time: 45.8 ms\n"
+      "CPU times: user 164 ms, sys: 1.75 ms, total: 166 ms\n",
+      "Wall time: 56.9 ms\n"
      ]
     }
    ],
@@ -394,7 +394,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x327c627f0>"
+       "<matplotlib.legend.Legend at 0x2e6792820>"
       ]
      },
      "execution_count": 13,
@@ -499,8 +499,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 19 µs, sys: 25 µs, total: 44 µs\n",
-      "Wall time: 47.2 µs\n"
+      "CPU times: user 20 µs, sys: 17 µs, total: 37 µs\n",
+      "Wall time: 41.2 µs\n"
      ]
     }
    ],
@@ -526,7 +526,7 @@
      "output_type": "stream",
      "text": [
       "INFO:maml.sampling.pca:Selected first 7 PCs, explaining 98.58% variance\n",
-      "INFO:maml.sampling.clustering:Birch threshold of 0.1 gives 1293 clusters.\n",
+      "INFO:maml.sampling.clustering:BirchClustering with threshold_init=0.1 and n=954 gives 954 clusters.\n",
       "INFO:maml.sampling.stratified_sampling:Finally selected 954 configurations.\n"
      ]
     },
@@ -534,8 +534,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 25.3 s, sys: 2.2 s, total: 27.5 s\n",
-      "Wall time: 8.03 s\n"
+      "CPU times: user 27.6 s, sys: 2.96 s, total: 30.5 s\n",
+      "Wall time: 9.14 s\n"
      ]
     }
    ],
@@ -586,22 +586,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 69.8 ms, sys: 36.5 ms, total: 106 ms\n",
-      "Wall time: 15 ms\n"
+      "CPU times: user 62.7 ms, sys: 5.38 ms, total: 68 ms\n",
+      "Wall time: 22.4 ms\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/rr/d33n0r7d06zc3bfdcz58s0w00000gn/T/ipykernel_23148/745124701.py:9: MatplotlibDeprecationWarning: The legendHandles attribute was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use legend_handles instead.\n",
+      "/var/folders/rr/d33n0r7d06zc3bfdcz58s0w00000gn/T/ipykernel_94549/1745198056.py:13: MatplotlibDeprecationWarning: The legendHandles attribute was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use legend_handles instead.\n",
       "  for lh in legend.legendHandles:\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x37ce84730>"
+       "<matplotlib.legend.Legend at 0x37d09acd0>"
       ]
      },
      "execution_count": 19,
@@ -645,22 +645,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 35.9 ms, sys: 3.16 ms, total: 39.1 ms\n",
-      "Wall time: 13.7 ms\n"
+      "CPU times: user 16.4 ms, sys: 2.61 ms, total: 19 ms\n",
+      "Wall time: 17.9 ms\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/rr/d33n0r7d06zc3bfdcz58s0w00000gn/T/ipykernel_23148/745124701.py:9: MatplotlibDeprecationWarning: The legendHandles attribute was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use legend_handles instead.\n",
+      "/var/folders/rr/d33n0r7d06zc3bfdcz58s0w00000gn/T/ipykernel_94549/1745198056.py:13: MatplotlibDeprecationWarning: The legendHandles attribute was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use legend_handles instead.\n",
       "  for lh in legend.legendHandles:\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x37ce84e50>"
+       "<matplotlib.legend.Legend at 0x37d0fe940>"
       ]
      },
      "execution_count": 20,
@@ -703,8 +703,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 565 ms, sys: 3.16 ms, total: 568 ms\n",
-      "Wall time: 552 ms\n"
+      "CPU times: user 706 ms, sys: 8.47 ms, total: 714 ms\n",
+      "Wall time: 717 ms\n"
      ]
     }
    ],
@@ -724,7 +724,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x37ceaf310>"
+       "<matplotlib.legend.Legend at 0x37d0ba820>"
       ]
      },
      "execution_count": 22,


### PR DESCRIPTION
## Summary
Clarify the logger message of BirchClustering. When n is set not to an integer instead of None, the number of clusters returned by BIRCH is actually equal to n, instead of the number of clusters dependent on threshold. This is discussed in details on the [documentation of sklearn for BIRCH](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.Birch.html), when n_clusters is an integer or None. 

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
