### PR TITLE
Fix `setup.py` package data so `pip install` without GitHub clone also works for `M3GNetStructure`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,8 +122,8 @@ setup(
     package_data={
         "maml": [
             "describers/data/*.json",
-            "describers/data/megnet_models/*.json",
-            "describers/data/megnet_mdoels/*.hdf5",
+            "describers/data/megnet_models/*",
+            "describers/data/m3gnet_models/matbench_mp_e_form/0/m3gnet/*",
         ]
     },
 )


### PR DESCRIPTION
When trying to parse `Structure` objects with `M3GNetStructure`, the following error is encountered:
```python
Traceback (most recent call last):
  File "M3GNet_Structure_DIRECT_generation_test_Y.py", line 35, in <module>
    m3gnet_struct = M3GNetStructure()  # neither multiprocessing nor Parallel works for this
  File "/work/e05/e05/kavanase/miniconda3/envs/tf_2.14_for_DIRECT/lib/python3.10/site-packages/maml/describers/_m3gnet.py", line 35, in __init__
    self.describer_model = M3GNet.from_dir(DEFAULT_MODEL)
  File "/work/e05/e05/kavanase/miniconda3/envs/tf_2.14_for_DIRECT/lib/python3.10/site-packages/m3gnet/models/_m3gnet.py", line 336, in from_dir
    model.load_weights(model_name)
  File "/work/e05/e05/kavanase/miniconda3/envs/tf_2.14_for_DIRECT/lib/python3.10/site-packages/keras/src/utils/traceback_utils.py", line 70, in error_handler
    raise e.with_traceback(filtered_tb) from None
  File "/work/e05/e05/kavanase/miniconda3/envs/tf_2.14_for_DIRECT/lib/python3.10/site-packages/tensorflow/python/training/py_checkpoint_reader.py", line 31, in error_translator
    raise errors_impl.NotFoundError(None, None, error_message)
tensorflow.python.framework.errors_impl.NotFoundError: Unsuccessful TensorSliceReader constructor: Failed to find any matching files for /work/e05/e05/kavanase/miniconda3/envs/tf_2.14_for_DIRECT/lib/python3.10/site-packages/maml/describers/data/m3gnet_models/matbench_mp_e_form/0/m3gnet/m3gnet
```
which seems to be because the M3GNet model data from `maml/describers/data/m3gnet_models/matbench_mp_e_form/0/m3gnet` is not available in the package data – so works fine for GitHub Actions tests run in the cloned repo, but not when actually used elsewhere in scripts/notebooks. Fixing `package_data` in `setup.py` fixes this.

Also fixes a typo in `setup.py` for `megnet_models` (previously `megnet_mdoels`).

I would also note that this also fails with recent `tensorflow` versions (`2.16`) which uses `keras` v3, giving the following error:
```python
Traceback (most recent call last):
  File "M3GNet_Structure_DIRECT_generation_test_Y.py", line 35, in <module>
    m3gnet_struct = M3GNetStructure()  # neither multiprocessing nor Parallel works for this
  File "/work/e05/e05/kavanase/miniconda3/envs/tf_2.14_for_DIRECT/lib/python3.10/site-packages/maml/describers/_m3gnet.py", line 35, in __init__
    self.describer_model = M3GNet.from_dir(DEFAULT_MODEL)
  File "/work/e05/e05/kavanase/miniconda3/envs/tf_2.14_for_DIRECT/lib/python3.10/site-packages/m3gnet/models/_m3gnet.py", line 336, in from_dir
    model.load_weights(model_name)
  File "/work/e05/e05/kavanase/miniconda3/envs/tf_2.14_for_DIRECT/lib/python3.10/site-packages/keras/src/utils/traceback_utils.py", line 122, in error_handler
    raise e.with_traceback(filtered_tb) from None
  File "/work/e05/e05/kavanase/miniconda3/envs/tf_2.14_for_DIRECT/lib/python3.10/site-packages/keras/src/saving/saving_api.py", line 262, in load_weights
    raise ValueError(
ValueError: File format not supported: filepath=/work/e05/e05/kavanase/miniconda3/envs/tf_2.14_for_DIRECT/lib/python3.10/site-packages/maml/describers/data/m3gnet_models/matbench_mp_e_form/0/m3gnet/m3gnet. Keras 3 only supports V3 `.keras` and `.weights.h5` files, or legacy V1/V2 `.h5` files.
```
while downgrading to `tensorflow==2.15` and `keras<3` fixes this issue. I'm not sure if you want to update the requirements for this, or update the code to work with recent versions. 

When fixing all these issues, the code runs, but also throws many warnings:
```
WARNING:tensorflow:From /work/e05/e05/kavanase/miniconda3/envs/tf_2.14_for_DIRECT/lib/python3.10/site-packages/tensorflow/python/util/deprecation.py:588: calling function (from tensorflow.python.eager.polymorphic_function.polymorphic_function) with experimental_relax_shapes is deprecated and will be removed in a future version.
Instructions for updating:
experimental_relax_shapes is deprecated, use reduce_retracing instead
WARNING:tensorflow:You are casting an input of type complex64 to an incompatible dtype float32.  This will discard the imaginary part and may not be what you intended.
... (many repeats of this)
WARNING:tensorflow:You are casting an input of type complex64 to an incompatible dtype float32.  This will discard the imaginary part and may not be what you intended.
WARNING:tensorflow:You are casting an input of type complex64 to an incompatible dtype float32.  This will discard the imaginary part and may not be what you intended.
WARNING:tensorflow:You are casting an input of type complex64 to an incompatible dtype float32.  This will discard the imaginary part and may not be what you intended.
WARNING:tensorflow:Detecting that an object or model or tf.train.Checkpoint is being deleted with unrestored values. See the following logs for the specific values in question. To silence these warnings, use `status.expect_partial()`. See https://www.tensorflow.org/api_docs/python/tf/train/Checkpoint#restorefor details about the status object returned by the restore function.
WARNING:tensorflow:Value in checkpoint could not be found in the restored object: (root).final.layers.1.pipe.layers.0.kernel
WARNING:tensorflow:Value in checkpoint could not be found in the restored object: (root).final.layers.1.pipe.layers.0.bias
WARNING:tensorflow:Value in checkpoint could not be found in the restored object: (root).final.layers.1.pipe.layers.1.kernel
WARNING:tensorflow:Value in checkpoint could not be found in the restored object: (root).final.layers.1.pipe.layers.1.bias
WARNING:tensorflow:Value in checkpoint could not be found in the restored object: (root).final.layers.1.pipe.layers.2.kernel
WARNING:tensorflow:Value in checkpoint could not be found in the restored object: (root).final.layers.1.pipe.layers.2.bias
```