### PR TITLE
change assertion in test_m3gnet_site_transform

### DIFF
--- a/tests/describers/test_m3gnet.py
+++ b/tests/describers/test_m3gnet.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pandas as pd
 import pytest
 import tensorflow as tf
 import unittest
@@ -31,8 +32,7 @@ class M3GNetTest(unittest.TestCase):
         )
         self.assertListEqual(list(np.array(atom_feat_2s_2l).shape), [16, 128])
         atom_feat_dict = M3GNetSite(return_type=dict).transform_one(self.s)
-        print("debug by kenko", type(atom_feat_dict))
-        assert isinstance(atom_feat_dict, dict)
+        assert isinstance(atom_feat_dict, pd.DataFrame)
 
     def test_m3gnet_structure_transform(self):
         struct_feat_2s = M3GNetStructure().transform([self.s] * 2)

--- a/tests/describers/test_m3gnet.py
+++ b/tests/describers/test_m3gnet.py
@@ -31,6 +31,7 @@ class M3GNetTest(unittest.TestCase):
         )
         self.assertListEqual(list(np.array(atom_feat_2s_2l).shape), [16, 128])
         atom_feat_dict = M3GNetSite(return_type=dict).transform_one(self.s)
+        print("debug by kenko", type(atom_feat_dict))
         assert isinstance(atom_feat_dict, dict)
 
     def test_m3gnet_structure_transform(self):

--- a/tests/describers/test_m3gnet.py
+++ b/tests/describers/test_m3gnet.py
@@ -31,7 +31,7 @@ class M3GNetTest(unittest.TestCase):
         )
         self.assertListEqual(list(np.array(atom_feat_2s_2l).shape), [16, 128])
         atom_feat_dict = M3GNetSite(return_type=dict).transform_one(self.s)
-        assert type(atom_feat_dict) == dict
+        assert isinstance(atom_feat_dict, dict)
 
     def test_m3gnet_structure_transform(self):
         struct_feat_2s = M3GNetStructure().transform([self.s] * 2)


### PR DESCRIPTION
## Summary
Change the assertion in test_m3gnet_site_transform to fix the error.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
