### PR TITLE
fix all docstrings for ruff

### DIFF
--- a/src/maml/apps/pes/_base.py
+++ b/src/maml/apps/pes/_base.py
@@ -26,6 +26,7 @@ class PotentialMixin:
                 each single structure case.
             train_stresses (list): List of DFT-calculated (6, ) virial stresses of
                 each structure in structures list.
+            **kwargs: optional keywords that can be added in the future.
         """
         raise NotImplementedError
 

--- a/src/maml/apps/pes/_gap.py
+++ b/src/maml/apps/pes/_gap.py
@@ -59,6 +59,7 @@ class GAPotential(LammpsPotential):
                 elements arranged in order [xx, yy, zz, xy, yz, xz].
 
         Returns:
+            outputs: a proper format storing structure, energy, forces, virial_stress.
         """
         full_virial_stress = [
             virial_stress[0],
@@ -137,6 +138,7 @@ class GAPotential(LammpsPotential):
 
         Args:
             filename (str): The configuration file to be read.
+            predict (bool): whether it is the prediction mode or not.
         """
         type_convert = {"R": np.float32, "I": np.int64, "S": np.str_}
         data_pool = []

--- a/src/maml/apps/pes/_nnp.py
+++ b/src/maml/apps/pes/_nnp.py
@@ -42,6 +42,9 @@ class NNPotential(LammpsPotential):
 
         Args:
             name (str): Name of force field.
+            param (str): Input parameters.
+            weight_param (dict): Atomic neural networks weights.
+            scaling_param (dict): Scaling parameters for symmetry functions.
         """
         self.name = name if name else "NNPotential"
         self.elements = None

--- a/src/maml/apps/pes/_snap.py
+++ b/src/maml/apps/pes/_snap.py
@@ -74,7 +74,8 @@ class SNAPotential(LammpsPotential):
             train_stresses (list): List of (6, ) virial stresses of each
                 structure in structures list.
             include_stress (bool): Whether to include stress components.
-            stress_format (string): stress format, default to VASP
+            stress_format (string): stress format, default to VASP.
+            **kwargs: additional keywords that can be added in the future.
         """
         train_structures, train_forces, train_stresses = check_structures_forces_stresses(
             train_structures, train_forces, train_stresses, stress_format=stress_format
@@ -174,6 +175,7 @@ class SNAPotential(LammpsPotential):
         Args:
             param_file (str): The file storing the configuration of potentials.
             coeff_file (str): The file storing the coefficients of potentials.
+            **kwargs: keywords that can be added in the future.
 
         Return:
             SNAPotential.

--- a/src/maml/sampling/pca.py
+++ b/src/maml/sampling/pca.py
@@ -1,3 +1,5 @@
+"""This file contains the PCA implementation."""
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
## Summary
Added all necessary descriptions for input arguments for ruff.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
