### PR TITLE
MatGL describer added

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "pymatgen",
     "mp-api",
     "scikit-learn>=1.6.1",
+    "matgl"
 ]
 version = "2025.4.3"
 
@@ -63,6 +64,7 @@ dev = [
     "pytest>=8.3.5",
     "pytest-cov>=6.0.0",
     "tensorflow>=2.18.1",
+    "matgl>=1.2.5",
     "pre-commit>=4.2.0",
 ]
 lint = [

--- a/src/maml/describers/__init__.py
+++ b/src/maml/describers/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from ._composition import ElementProperty, ElementStats
 from ._m3gnet import M3GNetSite, M3GNetStructure
+from ._matgl import MatGLSite, MatGLStructure
 from ._matminer import wrap_matminer_describer
 from ._megnet import MEGNetSite, MEGNetStructure
 from ._rdf import RadialDistributionFunction
@@ -31,6 +32,8 @@ __all__ = [
     "M3GNetStructure",
     "MEGNetSite",
     "MEGNetStructure",
+    "MatGLSite",
+    "MatGLStructure",
     "RadialDistributionFunction",
     "RandomizedCoulombMatrix",
     "SiteElementProperty",

--- a/src/maml/describers/_matgl.py
+++ b/src/maml/describers/_matgl.py
@@ -12,7 +12,6 @@ from maml.base import BaseDescriber, describer_type
 if TYPE_CHECKING:
     from pymatgen.core import Molecule, Structure
 
-# DEFAULT_MODEL = Path(__file__).parent / "data/m3gnet_models/matbench_mp_e_form/0/m3gnet/"
 DEFAULT_MODEL = "M3GNet-MP-2018.6.1-Eform"
 
 
@@ -30,8 +29,8 @@ class MatGLStructure(BaseDescriber):
 
         Args:
             model_path (str): m3gnet models path. If no path is provided,
-                the models will be M3GNet formation energy model on figshare:
-                https://figshare.com/articles/software/m3gnet_property_model_weights/20099465
+                the models will be M3GNet formation energy model on MatGL repo:
+                https://github.com/materialsvirtuallab/matgl/tree/main/pretrained_models/M3GNet-MP-2018.6.1-Eform
                 Please refer to the M3GNet paper:
                 https://doi.org/10.1038/s43588-022-00349-3.
             **kwargs: Pass through to BaseDescriber.
@@ -59,7 +58,7 @@ class MatGLStructure(BaseDescriber):
 
 @describer_type("site")
 class MatGLSite(BaseDescriber):
-    """Use M3GNet pre-trained models as featurizer to get atomic features."""
+    """Use MatGL pre-trained models as featurizer to get atomic features."""
 
     def __init__(
         self,
@@ -72,8 +71,8 @@ class MatGLSite(BaseDescriber):
 
         Args:
             model_path (str): m3gnet models path. If no path is provided,
-                the models will be M3GNet formation energy model on figshare:
-                https://figshare.com/articles/software/m3gnet_property_model_weights/20099465
+                the models will be M3GNet formation energy model on MatGL repo:
+                https://github.com/materialsvirtuallab/matgl/tree/main/pretrained_models/M3GNet-MP-2018.6.1-Eform
                 Please refer to the M3GNet paper:
                 https://doi.org/10.1038/s43588-022-00349-3.
             output_layers: List of names for the layer of GNN as output. Choose from "embedding", "gc_1", "gc_2",...,

--- a/src/maml/describers/_matgl.py
+++ b/src/maml/describers/_matgl.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import matgl
+import numpy as np
+import pandas as pd
+import torch
+
+from maml.base import BaseDescriber, describer_type
+
+if TYPE_CHECKING:
+    from pymatgen.core import Molecule, Structure
+
+# DEFAULT_MODEL = Path(__file__).parent / "data/m3gnet_models/matbench_mp_e_form/0/m3gnet/"
+DEFAULT_MODEL = "M3GNet-MP-2018.6.1-Eform"
+
+
+
+@describer_type("structure")
+class MatGLStructure(BaseDescriber):
+    """Use M3GNet pre-trained models as featurizer to get Structural features."""
+
+    def __init__(
+        self,
+        model_path: str | None = None,
+        **kwargs,
+    ):
+        """
+
+        Args:
+            model_path (str): m3gnet models path. If no path is provided,
+                the models will be M3GNet formation energy model on figshare:
+                https://figshare.com/articles/software/m3gnet_property_model_weights/20099465
+                Please refer to the M3GNet paper:
+                https://doi.org/10.1038/s43588-022-00349-3.
+            **kwargs: Pass through to BaseDescriber.
+        """
+        if model_path:
+            self.describer_model = matgl.load_model(model_path).model
+            self.model_path = model_path
+        else:
+            self.describer_model = matgl.load_model(DEFAULT_MODEL).model
+            self.model_path = DEFAULT_MODEL
+        super().__init__(**kwargs)
+
+    def transform_one(self, structure: Structure | Molecule):
+        """
+        Transform structure/molecule objects into structural features.
+
+        Args:
+            structure (Structure/Molecule): target object structure or molecule
+        Returns: M3GNet readout layer output as structural features.
+
+        """
+        results = self.describer_model.predict_structure(structure, return_features=True)
+        return np.array(torch.squeeze(results["readout"]).detach().cpu().numpy())
+
+
+@describer_type("site")
+class MatGLSite(BaseDescriber):
+    """Use M3GNet pre-trained models as featurizer to get atomic features."""
+
+    def __init__(
+        self,
+        model_path: str | None = None,
+        output_layers: list | None = None,
+        return_type: list | dict = pd.DataFrame,
+        **kwargs,
+    ):
+        """
+
+        Args:
+            model_path (str): m3gnet models path. If no path is provided,
+                the models will be M3GNet formation energy model on figshare:
+                https://figshare.com/articles/software/m3gnet_property_model_weights/20099465
+                Please refer to the M3GNet paper:
+                https://doi.org/10.1038/s43588-022-00349-3.
+            output_layers: List of names for the layer of GNN as output. Choose from "embedding", "gc_1", "gc_2",...,
+                "gc_n", where n is the total number of graph convolutional layers. By default, the node features in
+                "gc_1" layer are returned.
+            return_type: The data type of the returned the atom features. By default, atom features in different
+                output_layers are concatenated to one vector per atom, and a dataframe of vectors are returned.
+            **kwargs: Pass through to BaseDescriber. E.g., feature_batch="pandas_concat" is very useful (see test).
+        """
+        if model_path:
+            self.describer_model = matgl.load_model(model_path).model
+            self.model_path = model_path
+        else:
+            self.describer_model = matgl.load_model(DEFAULT_MODEL).model
+            self.model_path = DEFAULT_MODEL
+
+        allowed_output_layers = ["embedding"] + [f"gc_{i + 1}" for i in range(self.describer_model.n_blocks)]
+        if output_layers is None:
+            output_layers = ["gc_1"]
+        elif not isinstance(output_layers, list) or set(output_layers).difference(allowed_output_layers):
+            raise ValueError(f"Invalid output_layers, it must be a sublist of {allowed_output_layers}.")
+        self.output_layers = output_layers
+        self.return_type = return_type
+        super().__init__(**kwargs)
+
+    def transform_one(self, structure: Structure | Molecule):
+        """
+        Transform structure/molecule objects into atom features
+        Args:
+            structure (Structure/Molecule): target object structure or molecule
+        Returns: M3GNet node features as atom features.
+
+        """
+        result_dict = self.describer_model.predict_structure(
+            structure, output_layers=self.output_layers, return_features=True
+        )
+        atom_fea_dict = {}
+        for layer in self.output_layers:
+            atom_fea_dict[layer] = result_dict[layer]["node_feat"].detach().cpu().numpy()
+
+        if isinstance(self.return_type, dict):
+            return atom_fea_dict
+        print("debug by kenko", atom_fea_dict.values())
+        return pd.DataFrame(np.concatenate(list(atom_fea_dict.values()), axis=1))

--- a/src/maml/sampling/direct.py
+++ b/src/maml/sampling/direct.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
 
-from maml.describers import M3GNetStructure
+from maml.describers import M3GNetStructure, MatGLStructure
 
 from .clustering import BirchClustering
 from .pca import PrincipalComponentAnalysis
@@ -21,7 +21,7 @@ class DIRECTSampler(Pipeline):
 
     def __init__(
         self,
-        structure_encoder="M3GNet",
+        structure_encoder="MatGL",
         scaler="StandardScaler",
         pca="PrincipalComponentAnalysis",
         weighting_PCs=True,
@@ -42,7 +42,13 @@ class DIRECTSampler(Pipeline):
         select_k_from_clusters: Straitified sampling of k structures from
             each cluster.
         """
-        self.structure_encoder = M3GNetStructure() if structure_encoder == "M3GNet" else structure_encoder
+        if structure_encoder == "MatGL":
+            self.structure_encoder = MatGLStructure()
+        elif structure_encoder == "M3GNet":
+            self.structure_encoder = M3GNetStructure()
+        else:
+            self.structure_encoder = structure_encoder
+
         self.scaler = StandardScaler() if scaler == "StandardScaler" else scaler
         self.pca = (
             PrincipalComponentAnalysis(weighting_PCs=weighting_PCs) if pca == "PrincipalComponentAnalysis" else pca

--- a/tests/describers/test_matgl.py
+++ b/tests/describers/test_matgl.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import pandas as pd
+import pytest
+import tensorflow as tf
+from pymatgen.core import Lattice, Structure
+
+try:
+    import matgl
+except ImportError:
+    matgl = None
+
+from maml.describers import MatGLSite, MatGLStructure
+
+
+@unittest.skipIf(matgl is None, "MatGL package is required.")
+class MatGLTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.s = Structure.from_spacegroup("Fm-3m", Lattice.cubic(5.69169), ["Na", "Cl"], [[0, 0, 0], [0, 0, 0.5]])
+
+    def test_matgl_site_transform(self):
+        atom_feat_2s = MatGLSite(feature_batch="pandas_concat").transform([self.s] * 2)
+        self.assertListEqual(list(np.array(atom_feat_2s).shape), [16, 64])
+        with pytest.raises(ValueError, match="Invalid output_layers"):
+            MatGLSite(output_layers=["whatever"])
+        atom_feat_2s_2l = MatGLSite(output_layers=["embedding", "gc_3"], feature_batch="pandas_concat").transform(
+            [self.s] * 2
+        )
+        self.assertListEqual(list(np.array(atom_feat_2s_2l).shape), [16, 128])
+        atom_feat_dict = MatGLSite(return_type=dict).transform_one(self.s)
+        assert isinstance(atom_feat_dict, pd.DataFrame)
+
+    def test_matgl_structure_transform(self):
+        struct_feat_2s = MatGLStructure().transform([self.s] * 2)
+        self.assertListEqual(list(np.array(struct_feat_2s).shape), [2, 128])
+        # Tensorflow is tricky, as the M3GNet loaded here affects layers names of MEGNet loaded in MEGNet tests
+        tf.keras.backend.clear_session()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
I added a function MatGLStructure and MatGLSite with united tests to extract structure-wise and atom-wise features from pymatgen Structure. Now we can use MatGL featurizers to avoid using the original M3GNet repo due to the inconsistent version of tensorflow. Users can reproduce the result by specifying "M3GNet" in DirectSampler. However, the DGL dependency of MatGL due to MacOS needs to be addressed here and I am not sure how to tackle this. @shyue Please have a look.




## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced two new describers, MatGLStructure and MatGLSite, enabling extraction of structural and atomic features from crystal structures or molecules using pre-trained M3GNet models.
  - Made MatGLStructure the default structure encoder in relevant sampling workflows.

- **Bug Fixes**
  - Improved error handling for invalid output layer selection in MatGLSite.

- **Tests**
  - Added comprehensive tests for the new MatGL describers, covering feature extraction, output validation, and error cases.

- **Chores**
  - Updated dependencies to include the matgl package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->