### PR TITLE
Update documentation to fix broken notebooks link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -81,7 +81,7 @@ pip install -r requirements.txt
 
 # Usage
 
-Many Jupyter notebooks are available on usage. See [notebooks](/notebooks). We also have a tool and tutorial lecture
+Many Jupyter notebooks are available on usage. See [notebooks](../notebooks). We also have a tool and tutorial lecture
 at [nanoHUB](https://nanohub.org/resources/maml).
 
 # API documentation


### PR DESCRIPTION
In the maml documentation, the link to the `notebooks` is broken because it is referenced with respect to the `docs` directory rather than the base directory. I think this will fix it, but I have not rebuilt the docs to confirm.
