### PR TITLE
Fix external nav link title in `_config.yml`

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,7 +15,7 @@ plugins:
 # favicon_ico: "/assets/favicon.ico"
 
 nav_external_links:
-  - title: "MatGL on GitHub"
+  - title: "maml on GitHub"
     url: "https://github.com/materialsvirtuallab/maml"
 
 aux_links:


### PR DESCRIPTION
Small fix: The link in the docs said "MatGL on GitHub" instead of "maml on GitHub"
